### PR TITLE
Trivial text tweak

### DIFF
--- a/templates/wrapper.tt
+++ b/templates/wrapper.tt
@@ -30,7 +30,7 @@
 [% content -%]
     </div>
     <footer>
-CPAN Digger written by <a href="https://twitter.com/szabgab">@szabgab</a> / Code on <a href="https://github.com/szabgab/CPAN-Digger">Github</a> / Last updated: [% timestamp %] /
+CPAN Digger written by <a href="https://twitter.com/szabgab">@szabgab</a> / Code on <a href="https://github.com/szabgab/CPAN-Digger">GitHub</a> / Last updated: [% timestamp %] /
 Support the work via <a href="https://www.patreon.com/szabgab">Patreon</a> or <a href="https://github.com/sponsors/szabgab">GitHub</a>.
     </footer>
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->


### PR DESCRIPTION
Change "Github" to "GitHub" in the site footer.

I presume the HTML files are autogenerated and don't need to be included in this PR?